### PR TITLE
Allow @BeforeAll and @BeforeEach in JUnit5 classes to support @Mocked usage

### DIFF
--- a/main/src/mockit/integration/junit5/JMockitExtension.java
+++ b/main/src/mockit/integration/junit5/JMockitExtension.java
@@ -245,21 +245,12 @@ public final class JMockitExtension extends TestRunnerDecorator implements
          return method.getDeclaredAnnotation(BeforeEach.class) != null;
       }
 
-      @Override
-      public String toString() {
-         return "ParamContext{" +
-                 "hasInstance=" + (instance == null ?  "false" : "true")  +
-                 ", class=" + clazz +
-                 ", method=" + method +
-                 '}';
-      }
-
-      public String displayClass() {
+      String displayClass() {
          if (clazz == null) return "<no class reference>";
          return clazz.getName();
       }
 
-      public String displayMethod() {
+      String displayMethod() {
          if (method == null) return "<no method reference>";
          String methodPrefix = isBeforeAllMethod() ? "@BeforeAll " :
                  isBeforeEachMethod() ? "@BeforeEach " : "";
@@ -267,6 +258,15 @@ public final class JMockitExtension extends TestRunnerDecorator implements
                  .map(Class::getName)
                  .collect(Collectors.joining(", "));
          return methodPrefix + method.getName() + "(" + args + ")";
+      }
+
+      @Override
+      public String toString() {
+         return "ParamContext{" +
+                 "hasInstance=" + (instance == null ?  "false" : "true")  +
+                 ", class=" + clazz +
+                 ", method=" + method +
+                 '}';
       }
    }
 }

--- a/main/src/mockit/internal/util/Utilities.java
+++ b/main/src/mockit/internal/util/Utilities.java
@@ -6,6 +6,7 @@ package mockit.internal.util;
 
 import javax.annotation.*;
 import java.io.*;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.net.*;
 import java.security.*;
@@ -34,6 +35,16 @@ public final class Utilities
       if (!classMember.isAccessible()) {
          classMember.setAccessible(true);
       }
+   }
+
+   public static Method getAnnotatedMethod(Class<?> cls, Class<? extends Annotation> annotation) {
+      for (Method method : cls.getMethods()) if (method.getAnnotation(annotation) != null) return method;
+      return null;
+   }
+
+   public static Method getAnnotatedDeclaredMethod(Class<?> cls, Class<? extends Annotation> annotation) {
+      for (Method method : cls.getDeclaredMethods()) if (method.getAnnotation(annotation) != null) return method;
+      return null;
    }
 
    @Nonnull


### PR DESCRIPTION
## What's new

This previously would fail with an NPE
```java
@ExtendWith(JMockitExtension.class)
public class FooTest {
	private FooService service;

	@BeforeEach
	public void setup(@Mocked FooService service) {
		this.service = service;
	}
}
```
Now, JMockit can provide mocked services through parameter injection vs field injection for `@BeforeEach` and `@BeforeAll`.

## Additional debug for parameter injection failure

This also adds some debugging messages when the `JMockitExtension` fails to supply parameter values instead of a vague NPE.

An example:
```java
@TestInstance(TestInstance.Lifecycle.PER_CLASS)
@ExtendWith(JMockitExtension.class)
public class FooTest {
	@BeforeAll
	public void setup1() {
		System.out.println(".");
	}

	@BeforeAll
	public void setup2(@Mocked Foo f) {
		System.out.println(f);
	}

	@Test
	public void test(@Mocked Foo f) {
		System.out.println(f);
	}
}
```
This is a poorly made test, but is valid. In this case, the handling of `@BeforeAll` allows for only one declaration. This will now fail with the given message:
```
org.junit.jupiter.api.extension.ParameterResolutionException: Failed to resolve parameter [Foo arg0] in method [public void FooTest.setup2(Foo)]: JMockit failed to provide parameters to JUnit 5 ParameterResolver.
 - Class: FooTest
 - Method: @BeforeAll setup1()
```
Vs
```
org.junit.jupiter.api.extension.ParameterResolutionException: Failed to resolve parameter [Foo arg0] in method [public void FooTest.setup2(Foo)]: "parameterValues" is null
```