### PR TITLE
Bring back the withArgThat matcher

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -81,7 +81,6 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>2.2</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/main/src/main/java/mockit/internal/expectations/argumentMatching/HamcrestAdapter.java
+++ b/main/src/main/java/mockit/internal/expectations/argumentMatching/HamcrestAdapter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2006 JMockit developers
+ * This file is subject to the terms of the MIT license (see LICENSE.txt).
+ */
+package mockit.internal.expectations.argumentMatching;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import mockit.internal.reflection.FieldReflection;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.hamcrest.core.Is;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.IsSame;
+
+/**
+ * Adapts the <tt>org.hamcrest.Matcher</tt> interface to {@link ArgumentMatcher}.
+ */
+public final class HamcrestAdapter implements ArgumentMatcher<HamcrestAdapter> {
+    @Nonnull
+    private final Matcher<?> hamcrestMatcher;
+
+    public HamcrestAdapter(@Nonnull Matcher<?> matcher) {
+        hamcrestMatcher = matcher;
+    }
+
+    @Override
+    public boolean same(@Nonnull HamcrestAdapter other) {
+        return hamcrestMatcher == other.hamcrestMatcher;
+    }
+
+    @Override
+    public boolean matches(@Nullable Object argValue) {
+        return hamcrestMatcher.matches(argValue);
+    }
+
+    @Override
+    public void writeMismatchPhrase(@Nonnull ArgumentMismatch argumentMismatch) {
+        Description strDescription = new StringDescription();
+        hamcrestMatcher.describeTo(strDescription);
+        argumentMismatch.append(strDescription.toString());
+    }
+
+    @Nullable
+    public Object getInnerValue() {
+        Object innermostMatcher = getInnermostMatcher();
+        return getArgumentValueFromMatcherIfAvailable(innermostMatcher);
+    }
+
+    @Nonnull
+    private Object getInnermostMatcher() {
+        Matcher<?> innerMatcher = hamcrestMatcher;
+
+        while (innerMatcher instanceof Is || innerMatcher instanceof IsNot) {
+            innerMatcher = FieldReflection.getField(innerMatcher.getClass(), Matcher.class, innerMatcher);
+        }
+
+        assert innerMatcher != null;
+        return innerMatcher;
+    }
+
+    @Nullable
+    private static Object getArgumentValueFromMatcherIfAvailable(@Nonnull Object argMatcher) {
+        if (argMatcher instanceof IsEqual || argMatcher instanceof IsSame
+                || "org.hamcrest.number.OrderingComparison".equals(argMatcher.getClass().getName())) {
+            return FieldReflection.getField(argMatcher.getClass(), Object.class, argMatcher);
+        }
+
+        return null;
+    }
+}

--- a/main/src/main/java/mockit/internal/expectations/invocation/ArgumentValuesAndMatchers.java
+++ b/main/src/main/java/mockit/internal/expectations/invocation/ArgumentValuesAndMatchers.java
@@ -15,6 +15,7 @@ import mockit.internal.expectations.argumentMatching.AlwaysTrueMatcher;
 import mockit.internal.expectations.argumentMatching.ArgumentMatcher;
 import mockit.internal.expectations.argumentMatching.ArgumentMismatch;
 import mockit.internal.expectations.argumentMatching.EqualityMatcher;
+import mockit.internal.expectations.argumentMatching.HamcrestAdapter;
 import mockit.internal.expectations.argumentMatching.ReflectiveMatcher;
 
 abstract class ArgumentValuesAndMatchers {
@@ -139,7 +140,8 @@ abstract class ArgumentValuesAndMatchers {
 
     private boolean areNonEquivalentMatches(@Nonnull ArgumentValuesAndMatchers other,
             @Nonnull ArgumentMatcher<?> matcher1, @Nonnull ArgumentMatcher<?> matcher2, @Nonnegative int matcherIndex) {
-        return matcher1.getClass() == ReflectiveMatcher.class
+        Class<?> matcherClass = matcher1.getClass();
+        return matcherClass == ReflectiveMatcher.class || matcherClass == HamcrestAdapter.class
                 || !equivalentMatches(matcher1, values[matcherIndex], matcher2, other.values[matcherIndex]);
     }
 

--- a/main/src/main/java/mockit/internal/expectations/transformation/ArgumentMatching.java
+++ b/main/src/main/java/mockit/internal/expectations/transformation/ArgumentMatching.java
@@ -18,6 +18,7 @@ final class ArgumentMatching {
     private static final String ANY_FIELDS = "any anyString anyInt anyBoolean anyLong anyDouble anyFloat anyChar anyShort anyByte";
     private static final String WITH_METHODS = "with(Lmockit/Delegate;)Ljava/lang/Object; "
             + "withAny(Ljava/lang/Object;)Ljava/lang/Object; "
+            + "withArgThat(Lorg/hamcrest/Matcher;)Ljava/lang/Object; "
             + "withCapture()Ljava/lang/Object; withCapture(Ljava/util/List;)Ljava/lang/Object; "
             + "withCapture(Ljava/lang/Object;)Ljava/util/List; "
             + "withEqual(Ljava/lang/Object;)Ljava/lang/Object; withEqual(DD)D withEqual(FD)F "

--- a/main/src/test/java/mockit/ExpectationsWithArgMatchersTest.java
+++ b/main/src/test/java/mockit/ExpectationsWithArgMatchersTest.java
@@ -4,6 +4,9 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 import static mockit.ExpectationsWithArgMatchersTest.Delegates.collectionElement;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -164,6 +167,9 @@ public final class ExpectationsWithArgMatchersTest {
          *            the new value
          */
         void setValue(Exception ex) {
+        }
+
+        void setIntValue(int i) {
         }
 
         /**
@@ -346,6 +352,41 @@ public final class ExpectationsWithArgMatchersTest {
 
         List<String> values = asList("a", "B", "c");
         mock.setTextualValues(values);
+    }
+
+    @Test
+    public void expectInvocationsWithHamcrestMatcher() {
+        new Expectations() {
+            {
+                mock.setTextualValues(this.<Collection<String>>withArgThat(hasItem("B")));
+            }
+        };
+
+        List<String> values = asList("a", "B", "c");
+        mock.setTextualValues(values);
+    }
+
+    @Test
+    public void expectInvocationsWithHamcrestMatcher2() {
+        new Expectations() {
+            {
+                mock.setTextualValues(withArgThat(containsInAnyOrder("B", "c", "a")));
+            }
+        };
+
+        List<String> values = asList("a", "B", "c");
+        mock.setTextualValues(values);
+    }
+
+    @Test
+    public void expectInvocationWithMatcherContainingAnotherMatcher() {
+        new Expectations() {
+            {
+                mock.setIntValue(withArgThat(equalTo(3)));
+            }
+        };
+
+        mock.setIntValue(3);
     }
 
     /**

--- a/main/src/test/java/otherTests/JUnit4Test.java
+++ b/main/src/test/java/otherTests/JUnit4Test.java
@@ -1,5 +1,6 @@
 package otherTests;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -135,6 +136,8 @@ public final class JUnit4Test {
                 result = "ABC";
                 anotherMock.getModifiedValue(withMatch("\\d+"));
                 result = "number";
+                anotherMock.getModifiedValue(withArgThat(is("test")));
+                result = "test";
 
                 anotherMock.getModifiedValue("Delegate");
                 result = new Delegate() {
@@ -156,13 +159,14 @@ public final class JUnit4Test {
         assertEquals("abc", anotherMock.getModifiedValue("TX test"));
         assertEquals("ABC", anotherMock.getModifiedValue("test X"));
         assertEquals("number", anotherMock.getModifiedValue("123"));
+        assertEquals("test", anotherMock.getModifiedValue("test"));
         assertEquals("delegate", anotherMock.getModifiedValue("Delegate"));
 
         new Verifications() {
             {
                 List<String> values = new ArrayList<>();
                 anotherMock.getModifiedValue(withCapture(values));
-                assertEquals(5, values.size());
+                assertEquals(6, values.size());
             }
         };
     }


### PR DESCRIPTION
By rolling back these two commits:

commit 6d71b54ca014f1da97c661af1debbf11a247685d
Author: rliesenfeld <rliesenfeld@gmail.com>
Date:   Sun Sep 30 16:34:23 2018 -0300

    Removed the "withArgThat" deprecated method.

commit f93923c4ca231be544097b97e6cba281990d5657
Author: rliesenfeld <rliesenfeld@gmail.com>
Date:   Wed Sep 26 18:40:38 2018 -0300

    Deprecated the "withArgThat(org.hamcrest.Matcher)" method (from Expectations/Verifications).