### PR TITLE
 Bring back @mocked(stubOutClassInitialization="true")

### DIFF
--- a/main/src/main/java/mockit/Mocked.java
+++ b/main/src/main/java/mockit/Mocked.java
@@ -66,8 +66,7 @@ public @interface Mocked {
      * static initialization of a class <em>once</em>, so stubbing out the initialization code can have unexpected
      * consequences. Stubbing out the static initialization of a class is an unsafe operation, which can cause other
      * tests, executed later in the same test run, to unexpectedly fail; instead of resorting to stubbing out a class's
-     * static initializer, the root cause for wanting to stub it out should be eliminated. This attribute will be
-     * removed in a future version.
+     * static initializer, the root cause for wanting to stub it out should be eliminated. Caveat Emptor.
      */
     boolean stubOutClassInitialization() default false;
 }

--- a/main/src/main/java/mockit/Mocked.java
+++ b/main/src/main/java/mockit/Mocked.java
@@ -47,10 +47,27 @@ import java.lang.annotation.Target;
  * applies to all cascading levels, and even to the type of the mock field/parameter itself (ie, if a method in
  * class/interface "<code>A</code>" has return type <code>A</code>, then it will return itself by default). Finally,
  * when new cascaded instances are created, {@linkplain Injectable @Injectable} semantics apply.
+ * <p>
+ * Static <em>class initializers</em> (including assignments to <em>static</em> fields) of a mocked class are not
+ * affected, unless {@linkplain #stubOutClassInitialization specified otherwise}.
  *
  * @see <a href="http://jmockit.github.io/tutorial/Mocking.html#mocked" target="tutorial">Tutorial</a>
  */
 @Retention(RUNTIME)
 @Target({ FIELD, PARAMETER })
 public @interface Mocked {
+    /**
+     * Indicates whether <em>static initialization code</em> in the mocked class should be stubbed out or not. Static
+     * initialization includes the execution of assignments to static fields of the class and the execution of static
+     * initialization blocks, if any. (Note that <em>static final</em> fields initialized with <em>compile-time</em>
+     * constants are not assigned at runtime, remaining unaffected whether the class is stubbed out or not.)
+     * <p>
+     * By default, static initialization code in a mocked class is <em>not</em> stubbed out. The JVM will only perform
+     * static initialization of a class <em>once</em>, so stubbing out the initialization code can have unexpected
+     * consequences. Stubbing out the static initialization of a class is an unsafe operation, which can cause other
+     * tests, executed later in the same test run, to unexpectedly fail; instead of resorting to stubbing out a class's
+     * static initializer, the root cause for wanting to stub it out should be eliminated. This attribute will be
+     * removed in a future version.
+     */
+    boolean stubOutClassInitialization() default false;
 }

--- a/main/src/main/java/mockit/internal/expectations/mocking/BaseTypeRedefinition.java
+++ b/main/src/main/java/mockit/internal/expectations/mocking/BaseTypeRedefinition.java
@@ -82,7 +82,9 @@ class BaseTypeRedefinition {
         if (targetClass == TypeVariable.class || targetClass.isInterface()) {
             createMockedInterfaceImplementationAndInstanceFactory(typeToMock);
         } else {
-            TestRun.ensureThatClassIsInitialized(targetClass);
+            if (typeMetadata == null || !typeMetadata.isClassInitializationToBeStubbedOut()) {
+                TestRun.ensureThatClassIsInitialized(targetClass);
+            }
             redefineTargetClassAndCreateInstanceFactory(typeToMock);
         }
 

--- a/main/src/main/java/mockit/internal/expectations/mocking/MockedType.java
+++ b/main/src/main/java/mockit/internal/expectations/mocking/MockedType.java
@@ -221,6 +221,10 @@ public final class MockedType extends InjectionProvider {
         return field == null || isFinal(accessModifiers);
     }
 
+    boolean isClassInitializationToBeStubbedOut() {
+        return mocked != null && mocked.stubOutClassInitialization();
+    }
+
     boolean withInstancesToCapture() {
         return getMaxInstancesToCapture() > 0;
     }

--- a/main/src/test/java/mockit/ExpectationsUsingMockedTest.java
+++ b/main/src/test/java/mockit/ExpectationsUsingMockedTest.java
@@ -103,6 +103,21 @@ public final class ExpectationsUsingMockedTest {
         assertFalse(base.add(2));
     }
 
+    static class ClassWithStaticInitializer {
+        static boolean initialized = true;
+
+        static int initialized() {
+            return initialized ? 1 : -1;
+        }
+    }
+
+    @Test
+    public void stubOutStaticInitializersWhenSpecified(
+            @Mocked(stubOutClassInitialization = true) ClassWithStaticInitializer unused) {
+        assertEquals(0, ClassWithStaticInitializer.initialized());
+        assertFalse(ClassWithStaticInitializer.initialized);
+    }
+
     /**
      * The Class ClassWithStaticInitializer2.
      */
@@ -161,6 +176,22 @@ public final class ExpectationsUsingMockedTest {
     public void mockEverythingWithoutStubbingStaticInitializers(@Mocked AnotherClassWithStaticInitializer unused) {
         assertEquals(0, AnotherClassWithStaticInitializer.initialized());
         assertTrue(AnotherClassWithStaticInitializer.initialized);
+    }
+
+    static class AnotherClassWithStaticInitializer2 {
+        static boolean initialized = true;
+
+        static int initialized() {
+            return initialized ? 1 : -1;
+        }
+    }
+
+    @Test
+    @SuppressWarnings("DefaultAnnotationParam")
+    public void avoidStubbingStaticInitializersThroughSpecificAnnotationAttribute(
+            @Mocked(stubOutClassInitialization = false) AnotherClassWithStaticInitializer2 unused) {
+        assertEquals(0, AnotherClassWithStaticInitializer2.initialized());
+        assertTrue(AnotherClassWithStaticInitializer2.initialized);
     }
 
     /**


### PR DESCRIPTION
By rolling back these commits:

commit https://github.com/hazendaz/jmockit1/commit/e21f16ed4d62edcd8144c2ed3f272d896d6123d0
Date:   Sun Mar 31 23:17:27 2019 -0300

    Removed the deprecated "stubOutClassInitialization" attribute of @mocked.

commit https://github.com/hazendaz/jmockit1/commit/b97623b38bfc5acaeac66441fd41c530bcb2d486
Date:   Thu Mar 14 22:01:40 2019 -0300

    Deprecated the "stubOutClassInitialization" attribute of @mocked.