### PR TITLE
Restore partial mocking of class literals via the Mocking api

### DIFF
--- a/main/src/main/java/mockit/internal/expectations/mocking/CaptureOfNewInstances.java
+++ b/main/src/main/java/mockit/internal/expectations/mocking/CaptureOfNewInstances.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 import mockit.asm.classes.ClassReader;
 import mockit.asm.types.JavaType;
 import mockit.internal.BaseClassModifier;
+import mockit.internal.ClassFile;
 import mockit.internal.capturing.CaptureOfImplementations;
 import mockit.internal.startup.Startup;
 import mockit.internal.state.MockFixture;
@@ -65,9 +66,38 @@ public class CaptureOfNewInstances extends CaptureOfImplementations<MockedType> 
 
     @Nonnull
     private final Map<Class<?>, List<Capture>> baseTypeToCaptures;
+    @Nonnull
+    private final List<Class<?>> partiallyMockedBaseTypes;
 
     CaptureOfNewInstances() {
         baseTypeToCaptures = new HashMap<>();
+        partiallyMockedBaseTypes = new ArrayList<>();
+    }
+
+    void useDynamicMocking(@Nonnull Class<?> baseType) {
+        partiallyMockedBaseTypes.add(baseType);
+
+        List<Class<?>> mockedClasses = TestRun.mockFixture().getMockedClasses();
+
+        for (Class<?> mockedClass : mockedClasses) {
+            if (baseType.isAssignableFrom(mockedClass)) {
+                if (mockedClass != baseType || !baseType.isInterface()) {
+                    redefineClassForDynamicPartialMocking(baseType, mockedClass);
+                }
+            }
+        }
+    }
+
+    private static void redefineClassForDynamicPartialMocking(@Nonnull Class<?> baseType,
+            @Nonnull Class<?> mockedClass) {
+        ClassReader classReader = ClassFile.createReaderOrGetFromCache(mockedClass);
+
+        MockedClassModifier modifier = newModifier(mockedClass.getClassLoader(), classReader, baseType, null);
+        modifier.useDynamicMocking(true);
+        classReader.accept(modifier);
+        byte[] modifiedClassfile = modifier.toByteArray();
+
+        Startup.redefineMethods(mockedClass, modifiedClassfile);
     }
 
     @Nonnull
@@ -76,12 +106,24 @@ public class CaptureOfNewInstances extends CaptureOfImplementations<MockedType> 
     }
 
     @Nonnull
-    @Override
-    protected BaseClassModifier createModifier(@Nullable ClassLoader cl, @Nonnull ClassReader cr,
+    private static MockedClassModifier newModifier(@Nullable ClassLoader cl, @Nonnull ClassReader cr,
             @Nonnull Class<?> baseType, @Nullable MockedType typeMetadata) {
         MockedClassModifier modifier = new MockedClassModifier(cl, cr, typeMetadata);
         String baseTypeDesc = JavaType.getInternalName(baseType);
         modifier.setClassNameForCapturedInstanceMethods(baseTypeDesc);
+        return modifier;
+    }
+
+    @Nonnull
+    @Override
+    protected BaseClassModifier createModifier(@Nullable ClassLoader cl, @Nonnull ClassReader cr,
+            @Nonnull Class<?> baseType, @Nullable MockedType typeMetadata) {
+        MockedClassModifier modifier = newModifier(cl, cr, baseType, typeMetadata);
+
+        if (partiallyMockedBaseTypes.contains(baseType)) {
+            modifier.useDynamicMocking(true);
+        }
+
         return modifier;
     }
 
@@ -184,5 +226,6 @@ public class CaptureOfNewInstances extends CaptureOfImplementations<MockedType> 
 
     public void cleanUp() {
         baseTypeToCaptures.clear();
+        partiallyMockedBaseTypes.clear();
     }
 }

--- a/main/src/main/java/mockit/internal/expectations/mocking/FieldTypeRedefinition.java
+++ b/main/src/main/java/mockit/internal/expectations/mocking/FieldTypeRedefinition.java
@@ -25,7 +25,7 @@ final class FieldTypeRedefinition extends TypeRedefinition {
     @Override
     void configureClassModifier(@Nonnull MockedClassModifier modifier) {
         if (usePartialMocking) {
-            modifier.useDynamicMocking();
+            modifier.useDynamicMocking(true);
         }
     }
 

--- a/main/src/main/java/mockit/internal/state/MockFixture.java
+++ b/main/src/main/java/mockit/internal/state/MockFixture.java
@@ -120,6 +120,7 @@ public final class MockFixture {
      * A list of "capturing" class file transformers, used by both the mocking and faking APIs.
      *
      * @see #addCaptureTransformer(CaptureTransformer)
+     * @see #findCaptureOfImplementations(Class)
      * @see #areCapturedClasses(Class, Class)
      * @see #isCaptured(Object)
      * @see #getCaptureTransformerCount()
@@ -414,13 +415,23 @@ public final class MockFixture {
 
     // The following methods are only used by the Mocking API.
 
-    public boolean isCaptured(@Nonnull Object mockedInstance) {
-        if (!captureTransformers.isEmpty()) {
-            Class<?> mockedClass = getMockedClass(mockedInstance);
-            return isCaptured(mockedClass);
+    @Nullable
+    public CaptureOfNewInstances findCaptureOfImplementations(@Nonnull Class<?> capturedType) {
+        for (CaptureTransformer<?> captureTransformer : captureTransformers) {
+            CaptureOfNewInstances capture = captureTransformer.getCaptureOfImplementationsIfApplicable(capturedType);
+
+            if (capture != null) {
+                return capture;
+            }
         }
 
-        return false;
+        return null;
+    }
+
+    public boolean isCaptured(@Nonnull Object mockedInstance) {
+        Class<?> mockedClass = getMockedClass(mockedInstance);
+        CaptureOfNewInstances capture = findCaptureOfImplementations(mockedClass);
+        return capture != null;
     }
 
     private boolean isCaptured(@Nonnull Class<?> mockedClass) {

--- a/main/src/test/java/mockit/PartialMockingTest.java
+++ b/main/src/test/java/mockit/PartialMockingTest.java
@@ -131,11 +131,6 @@ public final class PartialMockingTest {
      */
     @Test
     public void attemptToPartiallyMockAClass() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid Class");
-        thrown.expectMessage("partial mocking");
-        thrown.expectMessage("Collaborator");
-
         new Expectations(Collaborator.class) {
         };
     }


### PR DESCRIPTION
This is a WIP. Compiles but tests fail.

A rollback of: https://github.com/hazendaz/jmockit1/commit/825ab79cb79dcd67be3dc2d4291edeed30a3902a

Also a rollback of related commits:

https://github.com/hazendaz/jmockit1/commit/053e9ac21142c2488f75afdb7f3066a85b0ea041 https://github.com/hazendaz/jmockit1/commit/d3bcd4c90bbb4a17ca59b0164c272bc9ca803228 https://github.com/hazendaz/jmockit1/commit/853b63735a861241040061ecfd8d0b95a2b16f3c

However, commit https://github.com/hazendaz/jmockit1/commit/7cc93620c52ebbb1b5f15682ce4ab54521c5cc06 which came after this refactored this code making it difficult to apply them cleanly.