### PR TITLE
[tests] Rewrite fixMethodOrder tests to junit 5 and move one module a…

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        java-version: 21
+        distribution: 'temurin'
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:

--- a/main/src/test/java/mockit/CascadingFieldTest.java
+++ b/main/src/test/java/mockit/CascadingFieldTest.java
@@ -7,21 +7,21 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.runners.MethodSorters.NAME_ASCENDING;
 
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 /**
  * The Class CascadingFieldTest.
  */
-@FixMethodOrder(NAME_ASCENDING)
-public final class CascadingFieldTest {
+@TestMethodOrder(MethodName.class)
+final class CascadingFieldTest {
 
     /**
      * The Class Foo.
@@ -254,8 +254,8 @@ public final class CascadingFieldTest {
     /**
      * Record common expectations.
      */
-    @Before
-    public void recordCommonExpectations() {
+    @BeforeEach
+    void recordCommonExpectations() {
         new Expectations() {
             {
                 Bar bar = foo.getBar();
@@ -271,7 +271,7 @@ public final class CascadingFieldTest {
      * Obtain cascaded instances at all levels.
      */
     @Test
-    public void obtainCascadedInstancesAtAllLevels() {
+    void obtainCascadedInstancesAtAllLevels() {
         assertNotNull(foo.getBar());
         assertNotNull(foo.getBar().getList());
         assertNotNull(foo.getBar().getBaz());
@@ -286,7 +286,7 @@ public final class CascadingFieldTest {
      * Obtain cascaded instances at all levels again.
      */
     @Test
-    public void obtainCascadedInstancesAtAllLevelsAgain() {
+    void obtainCascadedInstancesAtAllLevelsAgain() {
         Bar bar = foo.getBar();
         assertNotNull(bar);
         assertNotNull(bar.getList());
@@ -301,7 +301,7 @@ public final class CascadingFieldTest {
      * Cascade one level.
      */
     @Test
-    public void cascadeOneLevel() {
+    void cascadeOneLevel() {
         assertTrue(foo.getBar().isDone());
         assertEquals(0, foo.getBar().doSomething());
         assertEquals(0, Foo.globalBar().doSomething());
@@ -326,7 +326,7 @@ public final class CascadingFieldTest {
      * Exercise cascading mock again.
      */
     @Test
-    public void exerciseCascadingMockAgain() {
+    void exerciseCascadingMockAgain() {
         assertTrue(foo.getBar().isDone());
     }
 
@@ -339,7 +339,7 @@ public final class CascadingFieldTest {
      *            the foo 2
      */
     @Test
-    public void recordUnambiguousExpectationsProducingDifferentCascadedInstances(@Mocked final Foo foo1,
+    void recordUnambiguousExpectationsProducingDifferentCascadedInstances(@Mocked final Foo foo1,
             @Mocked final Foo foo2) {
         new Expectations() {
             {
@@ -358,7 +358,7 @@ public final class CascadingFieldTest {
      * Record ambiguous expectations on instance method producing the same cascaded instance.
      */
     @Test
-    public void recordAmbiguousExpectationsOnInstanceMethodProducingTheSameCascadedInstance() {
+    void recordAmbiguousExpectationsOnInstanceMethodProducingTheSameCascadedInstance() {
         new Expectations() {
             {
                 Bar c1 = foo.getBar();
@@ -376,7 +376,7 @@ public final class CascadingFieldTest {
      * Record ambiguous expectations on static method producing the same cascaded instance.
      */
     @Test
-    public void recordAmbiguousExpectationsOnStaticMethodProducingTheSameCascadedInstance() {
+    void recordAmbiguousExpectationsOnStaticMethodProducingTheSameCascadedInstance() {
         new Expectations() {
             {
                 Bar c1 = Foo.globalBar();
@@ -400,7 +400,7 @@ public final class CascadingFieldTest {
      *            the bar 2
      */
     @Test
-    public void recordAmbiguousExpectationWithMultipleCascadingCandidatesFollowedByExpectationRecordedOnFirstCandidate(
+    void recordAmbiguousExpectationWithMultipleCascadingCandidatesFollowedByExpectationRecordedOnFirstCandidate(
             @Injectable final Bar bar1, @Injectable Bar bar2) {
         new Expectations() {
             {
@@ -435,7 +435,7 @@ public final class CascadingFieldTest {
      * Cascading mock field.
      */
     @Test
-    public void cascadingMockField() {
+    void cascadingMockField() {
         new Expectations() {
             {
                 anotherFoo.getBar().doSomething();
@@ -450,7 +450,7 @@ public final class CascadingFieldTest {
      * Cascading instance accessed from delegate method.
      */
     @Test
-    public void cascadingInstanceAccessedFromDelegateMethod() {
+    void cascadingInstanceAccessedFromDelegateMethod() {
         new Expectations() {
             {
                 foo.getIntValue();
@@ -499,7 +499,7 @@ public final class CascadingFieldTest {
      * Call method on non cascaded instance from custom argument matcher with cascaded instance also created.
      */
     @Test
-    public void callMethodOnNonCascadedInstanceFromCustomArgumentMatcherWithCascadedInstanceAlsoCreated() {
+    void callMethodOnNonCascadedInstanceFromCustomArgumentMatcherWithCascadedInstanceAlsoCreated() {
         Baz nonCascadedInstance = new Baz(E.A);
         Baz cascadedInstance = bazCreatorAndConsumer.create();
         assertNotSame(nonCascadedInstance, cascadedInstance);
@@ -544,7 +544,7 @@ public final class CascadingFieldTest {
      *            the mock
      */
     @Test
-    public void cascadeGenericMethodFromSpecializedGenericClass(@Mocked GenericBaseClass1<C> mock) {
+    void cascadeGenericMethodFromSpecializedGenericClass(@Mocked GenericBaseClass1<C> mock) {
         C value = mock.getValue();
         assertNotNull(value);
     }
@@ -562,7 +562,7 @@ public final class CascadingFieldTest {
      *            the mock
      */
     @Test
-    public void cascadeGenericMethodOfConcreteSubclassWhichExtendsGenericClass(@Mocked final ConcreteSubclass1 mock) {
+    void cascadeGenericMethodOfConcreteSubclassWhichExtendsGenericClass(@Mocked final ConcreteSubclass1 mock) {
         new Expectations() {
             {
                 mock.getValue().getB().getC();
@@ -620,7 +620,7 @@ public final class CascadingFieldTest {
      *            the mock
      */
     @Test
-    public void cascadeGenericMethodOfSubclassWhichExtendsGenericClassWithUpperBoundUsingInterface(
+    void cascadeGenericMethodOfSubclassWhichExtendsGenericClassWithUpperBoundUsingInterface(
             @Mocked final ConcreteSubclass2 mock) {
         Ab value = mock.getValue();
         assertNotNull(value);
@@ -641,7 +641,7 @@ public final class CascadingFieldTest {
      *            the mock
      */
     @Test
-    public void cascadeGenericMethodOfSubclassWhichExtendsGenericClassWithUpperBoundOnlyInVerificationBlock(
+    void cascadeGenericMethodOfSubclassWhichExtendsGenericClassWithUpperBoundOnlyInVerificationBlock(
             @Mocked final ConcreteSubclass2 mock) {
         new FullVerifications() {
             {
@@ -678,7 +678,7 @@ public final class CascadingFieldTest {
      *            the mock
      */
     @Test
-    public void cascadeGenericMethodOfSubclassWhichExtendsGenericClassWithUpperBoundUsingClass(
+    void cascadeGenericMethodOfSubclassWhichExtendsGenericClassWithUpperBoundUsingClass(
             @Mocked final ActionHolder mock) {
         new Expectations() {
             {
@@ -755,7 +755,7 @@ public final class CascadingFieldTest {
      * Use subclass mocked through cascading.
      */
     @Test
-    public void useSubclassMockedThroughCascading() {
+    void useSubclassMockedThroughCascading() {
         Derived1 d1 = factory1.get1(); // cascade-mocks Derived1 (per-instance)
         Long v1 = d1.value();
         assertNull(v1);
@@ -771,7 +771,7 @@ public final class CascadingFieldTest {
      *            the d 2
      */
     @Test
-    public void useSubclassPreviouslyMockedThroughCascadingWhileMockingSiblingSubclass(@Injectable Derived2 d2) {
+    void useSubclassPreviouslyMockedThroughCascadingWhileMockingSiblingSubclass(@Injectable Derived2 d2) {
         Long v1 = new Derived1().value();
         assertEquals(123, v1.longValue());
 

--- a/main/src/test/java/mockit/CascadingParametersTest.java
+++ b/main/src/test/java/mockit/CascadingParametersTest.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.runners.MethodSorters.NAME_ASCENDING;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -30,16 +30,17 @@ import java.util.concurrent.Future;
 
 import mockit.internal.expectations.invocation.MissingInvocation;
 
-import org.junit.FixMethodOrder;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 /**
  * The Class CascadingParametersTest.
  */
 @SuppressWarnings("ConstantConditions")
-@FixMethodOrder(NAME_ASCENDING)
-public final class CascadingParametersTest {
+@TestMethodOrder(MethodName.class)
+final class CascadingParametersTest {
 
     /**
      * The Class Foo.
@@ -221,7 +222,7 @@ public final class CascadingParametersTest {
      *            the foo
      */
     @Test
-    public void cascadeOneLevelDuringReplay(@Mocked Foo foo) {
+    void cascadeOneLevelDuringReplay(@Mocked Foo foo) {
         cascadedBar1 = foo.getBar();
         assertEquals(0, cascadedBar1.doSomething());
 
@@ -251,7 +252,7 @@ public final class CascadingParametersTest {
      *            the foo
      */
     @Test
-    public void verifyThatPreviousCascadedInstancesHaveBeenDiscarded(@Mocked Foo foo) {
+    void verifyThatPreviousCascadedInstancesHaveBeenDiscarded(@Mocked Foo foo) {
         Bar bar = foo.getBar();
         assertNotSame(cascadedBar1, bar);
 
@@ -266,7 +267,7 @@ public final class CascadingParametersTest {
      *            the foo
      */
     @Test
-    public void verifyThatStaticMethodsAndConstructorsAreNotMockedWhenCascading(@Mocked Foo foo) {
+    void verifyThatStaticMethodsAndConstructorsAreNotMockedWhenCascading(@Mocked Foo foo) {
         foo.getBar();
 
         assertEquals("notMocked", Bar.staticMethod());
@@ -287,7 +288,7 @@ public final class CascadingParametersTest {
      *            the mock bar
      */
     @Test
-    public void verifyThatStaticMethodsAndConstructorsAreMockedWhenCascadedMockIsMockedNormally(@Mocked Foo mockFoo,
+    void verifyThatStaticMethodsAndConstructorsAreMockedWhenCascadedMockIsMockedNormally(@Mocked Foo mockFoo,
             @Mocked Bar mockBar) {
         assertSame(mockBar, mockFoo.getBar());
         assertEquals(0, mockBar.doSomething());
@@ -304,7 +305,7 @@ public final class CascadingParametersTest {
      *            the bar
      */
     @Test
-    public void useAvailableMockedInstanceOfSubclassAsCascadedInstance(@Mocked Foo foo, @Mocked SubBar bar) {
+    void useAvailableMockedInstanceOfSubclassAsCascadedInstance(@Mocked Foo foo, @Mocked SubBar bar) {
         Bar cascadedBar = foo.getBar();
 
         assertSame(bar, cascadedBar);
@@ -321,8 +322,8 @@ public final class CascadingParametersTest {
      *            the bar 2
      */
     @Test
-    public void replaceCascadedInstanceWithFirstOneOfTwoInjectableInstances(@Mocked final Foo foo,
-            @Injectable final Bar bar1, @Injectable Bar bar2) {
+    void replaceCascadedInstanceWithFirstOneOfTwoInjectableInstances(@Mocked final Foo foo, @Injectable final Bar bar1,
+            @Injectable Bar bar2) {
         new Expectations() {
             {
                 foo.getBar();
@@ -344,7 +345,7 @@ public final class CascadingParametersTest {
      *            the mock foo
      */
     @Test
-    public void cascadeOneLevelDuringRecord(@Mocked final Foo mockFoo) {
+    void cascadeOneLevelDuringRecord(@Mocked final Foo mockFoo) {
         final List<Integer> list = Arrays.asList(1, 2, 3);
 
         new Expectations() {
@@ -381,7 +382,7 @@ public final class CascadingParametersTest {
      *            the foo
      */
     @Test
-    public void cascadeOneLevelDuringVerify(@Mocked final Foo foo) {
+    void cascadeOneLevelDuringVerify(@Mocked final Foo foo) {
         Bar bar = foo.getBar();
         bar.doSomething();
         bar.doSomething();
@@ -417,7 +418,7 @@ public final class CascadingParametersTest {
      *            the foo
      */
     @Test
-    public void cascadeTwoLevelsDuringReplay(@Mocked Foo foo) {
+    void cascadeTwoLevelsDuringReplay(@Mocked Foo foo) {
         foo.getBar().getBaz().runIt();
     }
 
@@ -428,7 +429,7 @@ public final class CascadingParametersTest {
      *            the mock foo
      */
     @Test
-    public void cascadeTwoLevelsDuringRecord(@Mocked final Foo mockFoo) {
+    void cascadeTwoLevelsDuringRecord(@Mocked final Foo mockFoo) {
         new Expectations() {
             {
                 mockFoo.getBar().doSomething();
@@ -459,7 +460,7 @@ public final class CascadingParametersTest {
      *            the bar
      */
     @Test
-    public void cascadeOneLevelAndVerifyInvocationOnLastMockOnly(@Mocked Foo foo, @Injectable final Bar bar) {
+    void cascadeOneLevelAndVerifyInvocationOnLastMockOnly(@Mocked Foo foo, @Injectable final Bar bar) {
         Bar fooBar = foo.getBar();
         assertSame(bar, fooBar);
         fooBar.doSomething();
@@ -480,7 +481,7 @@ public final class CascadingParametersTest {
      *            the baz
      */
     @Test
-    public void cascadeTwoLevelsWithInvocationRecordedOnLastMockOnly(@Mocked Foo foo, @Mocked final Baz baz) {
+    void cascadeTwoLevelsWithInvocationRecordedOnLastMockOnly(@Mocked Foo foo, @Mocked final Baz baz) {
         new Expectations() {
             {
                 baz.runIt();
@@ -501,7 +502,7 @@ public final class CascadingParametersTest {
      *            the baz
      */
     @Test
-    public void cascadeTwoLevelsAndVerifyInvocationOnLastMockOnly(@Mocked Foo foo, @Mocked final Baz baz) {
+    void cascadeTwoLevelsAndVerifyInvocationOnLastMockOnly(@Mocked Foo foo, @Mocked final Baz baz) {
         Baz cascadedBaz = foo.getBar().getBaz();
         assertSame(baz, cascadedBaz);
         cascadedBaz.runIt();
@@ -525,7 +526,7 @@ public final class CascadingParametersTest {
      *             the exception
      */
     @Test
-    public void cascadeOnJREClasses(@Mocked final ProcessBuilder pb) throws Exception {
+    void cascadeOnJREClasses(@Mocked final ProcessBuilder pb) throws Exception {
         new Expectations() {
             {
                 ProcessBuilder sameBuilder = pb.directory((File) any);
@@ -553,8 +554,8 @@ public final class CascadingParametersTest {
      *            the pb 2
      */
     @Test
-    public void returnSameMockedInstanceThroughCascadingEvenWithMultipleCandidatesAvailable(
-            @Injectable ProcessBuilder pb1, @Injectable ProcessBuilder pb2) {
+    void returnSameMockedInstanceThroughCascadingEvenWithMultipleCandidatesAvailable(@Injectable ProcessBuilder pb1,
+            @Injectable ProcessBuilder pb2) {
         assertSame(pb1, pb1.command("a"));
         assertSame(pb2, pb2.command("b"));
     }
@@ -569,7 +570,7 @@ public final class CascadingParametersTest {
      *             the exception
      */
     @Test
-    public void createOSProcessToCopyTempFiles(@Mocked final ProcessBuilder pb) throws Exception {
+    void createOSProcessToCopyTempFiles(@Mocked final ProcessBuilder pb) throws Exception {
         // Code under test creates a new process to execute an OS-specific command.
         String cmdLine = "copy /Y *.txt D:\\TEMP";
         File wrkDir = new File("C:\\TEMP");
@@ -604,9 +605,9 @@ public final class CascadingParametersTest {
      *             the exception
      */
     // TODO JWL 2/18/2024 Test not allowed on jdk21
-    @Ignore
+    @Disabled
     @Test
-    public void recordAndVerifyExpectationsOnCascadedMocks(@Mocked Socket anySocket,
+    void recordAndVerifyExpectationsOnCascadedMocks(@Mocked Socket anySocket,
             @Mocked final SocketChannel cascadedChannel, @Mocked InetSocketAddress inetAddr) throws Exception {
         Socket sk = new Socket();
         SocketChannel ch = sk.getChannel();
@@ -670,7 +671,7 @@ public final class CascadingParametersTest {
      *             the exception
      */
     @Test
-    public void cascadeOneLevelWithArgumentMatchers(@Mocked final SocketFactory sf) throws Exception {
+    void cascadeOneLevelWithArgumentMatchers(@Mocked final SocketFactory sf) throws Exception {
         new Expectations() {
             {
                 sf.createSocket(anyString, 80);
@@ -692,7 +693,7 @@ public final class CascadingParametersTest {
      *             the exception
      */
     @Test
-    public void recordAndVerifyOneLevelDeep(@Mocked final SocketFactory sf) throws Exception {
+    void recordAndVerifyOneLevelDeep(@Mocked final SocketFactory sf) throws Exception {
         final OutputStream out = new ByteArrayOutputStream();
 
         new Expectations() {
@@ -717,7 +718,7 @@ public final class CascadingParametersTest {
      *             the exception
      */
     @Test
-    public void recordAndVerifyOnTwoCascadingMocksOfTheSameType(@Mocked final SocketFactory sf1,
+    void recordAndVerifyOnTwoCascadingMocksOfTheSameType(@Mocked final SocketFactory sf1,
             @Mocked final SocketFactory sf2) throws Exception {
         final OutputStream out1 = new ByteArrayOutputStream();
         final OutputStream out2 = new ByteArrayOutputStream();
@@ -752,7 +753,7 @@ public final class CascadingParametersTest {
      *             the exception
      */
     @Test
-    public void recordAndVerifySameInvocationOnMocksReturnedFromInvocationsWithDifferentArguments(
+    void recordAndVerifySameInvocationOnMocksReturnedFromInvocationsWithDifferentArguments(
             @Mocked final SocketFactory sf) throws Exception {
         new Expectations() {
             {
@@ -793,7 +794,7 @@ public final class CascadingParametersTest {
      *            the sc
      */
     @Test
-    public void cascadeOnInheritedMethod(@Mocked SocketChannel sc) {
+    void cascadeOnInheritedMethod(@Mocked SocketChannel sc) {
         assertNotNull(sc.provider());
     }
 
@@ -807,7 +808,7 @@ public final class CascadingParametersTest {
      *             the exception
      */
     @Test
-    public void recordAndVerifyWithMixedCascadeLevels(@Mocked final SocketFactory sf) throws Exception {
+    void recordAndVerifyWithMixedCascadeLevels(@Mocked final SocketFactory sf) throws Exception {
         new Expectations() {
             {
                 sf.createSocket("first", 80).getKeepAlive();
@@ -854,7 +855,7 @@ public final class CascadingParametersTest {
      *             the exception
      */
     @Test
-    public void cascadeAFuture(@Mocked SomeClass mock) throws Exception {
+    void cascadeAFuture(@Mocked SomeClass mock) throws Exception {
         Future<Foo> f = mock.doSomething();
         Foo foo = f.get();
 
@@ -872,7 +873,7 @@ public final class CascadingParametersTest {
      *            the mock bar
      */
     @Test
-    public void recordExpectationOnCascadedMock(@Mocked Foo foo, @Mocked final Bar mockBar) {
+    void recordExpectationOnCascadedMock(@Mocked Foo foo, @Mocked final Bar mockBar) {
         new Expectations() {
             {
                 mockBar.doSomething();
@@ -898,7 +899,7 @@ public final class CascadingParametersTest {
      *            the mock bar 2
      */
     @Test
-    public void overrideTwoCascadedMocksOfTheSameType(@Mocked final Foo foo1, @Mocked final Foo foo2,
+    void overrideTwoCascadedMocksOfTheSameType(@Mocked final Foo foo1, @Mocked final Foo foo2,
             @Mocked final Bar mockBar1, @Mocked final Bar mockBar2) {
         new Expectations() {
             {
@@ -929,29 +930,31 @@ public final class CascadingParametersTest {
      * @param mockBar2
      *            the mock bar 2
      */
-    @Test(expected = MissingInvocation.class)
-    public void overrideTwoCascadedMocksOfTheSameTypeButReplayInDifferentOrder(@Mocked final Foo foo1,
-            @Mocked final Foo foo2, @Injectable final Bar mockBar1, @Mocked final Bar mockBar2) {
-        new Expectations() {
-            {
-                foo1.getBar();
-                result = mockBar1;
-                foo2.getBar();
-                result = mockBar2;
-            }
-        };
+    @Test
+    void overrideTwoCascadedMocksOfTheSameTypeButReplayInDifferentOrder(@Mocked final Foo foo1, @Mocked final Foo foo2,
+            @Injectable final Bar mockBar1, @Mocked final Bar mockBar2) {
+        assertThrows(MissingInvocation.class, () -> {
+            new Expectations() {
+                {
+                    foo1.getBar();
+                    result = mockBar1;
+                    foo2.getBar();
+                    result = mockBar2;
+                }
+            };
 
-        Bar bar1 = foo1.getBar();
-        Bar bar2 = foo2.getBar();
-        bar2.doSomething();
-        bar1.doSomething();
+            Bar bar1 = foo1.getBar();
+            Bar bar2 = foo2.getBar();
+            bar2.doSomething();
+            bar1.doSomething();
 
-        new VerificationsInOrder() {
-            {
-                mockBar1.doSomething();
-                mockBar2.doSomething();
-            }
-        };
+            new VerificationsInOrder() {
+                {
+                    mockBar1.doSomething();
+                    mockBar2.doSomething();
+                }
+            };
+        });
     }
 
     /**
@@ -961,7 +964,7 @@ public final class CascadingParametersTest {
      *            the mock
      */
     @Test
-    public void cascadedEnum(@Mocked final Foo mock) {
+    void cascadedEnum(@Mocked final Foo mock) {
         new Expectations() {
             {
                 mock.getBar().getEnum();
@@ -979,7 +982,7 @@ public final class CascadingParametersTest {
      *            the mock
      */
     @Test
-    public void cascadedEnumReturningConsecutiveValuesThroughResultField(@Mocked final Foo mock) {
+    void cascadedEnumReturningConsecutiveValuesThroughResultField(@Mocked final Foo mock) {
         new Expectations() {
             {
                 mock.getBar().getEnum();
@@ -1001,7 +1004,7 @@ public final class CascadingParametersTest {
      *            the mock
      */
     @Test
-    public void cascadedEnumReturningConsecutiveValuesThroughReturnsMethod(@Mocked final Foo mock) {
+    void cascadedEnumReturningConsecutiveValuesThroughReturnsMethod(@Mocked final Foo mock) {
         new Expectations() {
             {
                 mock.getBar().getEnum();
@@ -1021,7 +1024,7 @@ public final class CascadingParametersTest {
      *            the foo
      */
     @Test
-    public void overrideLastCascadedObjectWithNonMockedInstance(@Mocked final Foo foo) {
+    void overrideLastCascadedObjectWithNonMockedInstance(@Mocked final Foo foo) {
         final Date newDate = new Date(123);
         assertEquals(123, newDate.getTime());
 
@@ -1045,7 +1048,7 @@ public final class CascadingParametersTest {
      *            the foo
      */
     @Test
-    public void returnDeclaredMockedInstanceFromMultiLevelCascading(@Mocked Date mockedDate, @Mocked Foo foo) {
+    void returnDeclaredMockedInstanceFromMultiLevelCascading(@Mocked Date mockedDate, @Mocked Foo foo) {
         Date newDate = new Date(123);
         assertEquals(0, newDate.getTime());
 
@@ -1065,7 +1068,7 @@ public final class CascadingParametersTest {
      *            the foo
      */
     @Test
-    public void returnInjectableMockInstanceFromMultiLevelCascading(@Injectable Date mockDate, @Mocked Foo foo) {
+    void returnInjectableMockInstanceFromMultiLevelCascading(@Injectable Date mockDate, @Mocked Foo foo) {
         Date newDate = new Date(123);
         assertEquals(123, newDate.getTime());
 
@@ -1121,7 +1124,7 @@ public final class CascadingParametersTest {
      *            the mock 2
      */
     @Test
-    public void cascadeDuringStaticInitializationOfCascadingClass(@Mocked Factory mock1, @Mocked Client mock2) {
+    void cascadeDuringStaticInitializationOfCascadingClass(@Mocked Factory mock1, @Mocked Client mock2) {
         assertNotNull(mock2.getOtherClient());
         assertNotNull(OtherClient.F);
     }
@@ -1157,7 +1160,7 @@ public final class CascadingParametersTest {
      *            the mock
      */
     @Test
-    public void createCascadedMockFromMethodDefinedTwoLevelsUpAnInterfaceHierarchy(@Mocked LevelTwo mock) {
+    void createCascadedMockFromMethodDefinedTwoLevelsUpAnInterfaceHierarchy(@Mocked LevelTwo mock) {
         assertNotNull(mock.getFoo());
     }
 
@@ -1174,7 +1177,7 @@ public final class CascadingParametersTest {
      *            the mock
      */
     @Test
-    public void cascadeTypeReturnedFromInterfaceImplementedByAbstractClass(@Mocked AbstractClass mock) {
+    void cascadeTypeReturnedFromInterfaceImplementedByAbstractClass(@Mocked AbstractClass mock) {
         Runnable foo = mock.getFoo();
         assertNotNull(foo);
     }
@@ -1186,7 +1189,7 @@ public final class CascadingParametersTest {
      *            the bar
      */
     @Test
-    public void produceDifferentCascadedInstancesOfSameInterfaceFromDifferentInvocations(@Mocked Bar bar) {
+    void produceDifferentCascadedInstancesOfSameInterfaceFromDifferentInvocations(@Mocked Bar bar) {
         Baz cascaded1 = bar.getBaz(1);
         Baz cascaded2 = bar.getBaz(2);
         Baz cascaded3 = bar.getBaz(1);
@@ -1202,7 +1205,7 @@ public final class CascadingParametersTest {
      *            the mngmnt factory
      */
     @Test
-    public void cascadeFromJavaManagementAPI(@Mocked ManagementFactory mngmntFactory) {
+    void cascadeFromJavaManagementAPI(@Mocked ManagementFactory mngmntFactory) {
         CompilationMXBean compilation = ManagementFactory.getCompilationMXBean();
 
         assertNotNull(compilation);
@@ -1228,7 +1231,7 @@ public final class CascadingParametersTest {
      *            the mock
      */
     @Test
-    public void cascadeFromMethodInPublicInterfaceReturningPackagePrivateType(@Mocked AnInterface mock) {
+    void cascadeFromMethodInPublicInterfaceReturningPackagePrivateType(@Mocked AnInterface mock) {
         NonPublicTestedClass ret = mock.getPackagePrivateClass();
 
         assertNull(ret);
@@ -1263,7 +1266,7 @@ public final class CascadingParametersTest {
      *            the mock
      */
     @Test
-    public void cascadeFromMethodReturningAThrowableSubclass(@Mocked AClass mock) {
+    void cascadeFromMethodReturningAThrowableSubclass(@Mocked AClass mock) {
         CustomException t = mock.getException();
 
         assertNull(t);
@@ -1309,10 +1312,11 @@ public final class CascadingParametersTest {
      *            the first
      */
     @Test
-    public void cascadeFromMethodReturningTypeProvidedByClassParameterThenFromCascadedInstance(@Mocked First first) {
+    void cascadeFromMethodReturningTypeProvidedByClassParameterThenFromCascadedInstance(@Mocked First first) {
         Second second = first.getSecond(Second.class);
         Runnable runnable = second.getSomething();
 
         assertNotNull(runnable);
     }
+
 }

--- a/main/src/test/java/mockit/CascadingWithGenericsTest.java
+++ b/main/src/test/java/mockit/CascadingWithGenericsTest.java
@@ -11,15 +11,15 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 /**
  * The Class CascadingWithGenericsTest.
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public final class CascadingWithGenericsTest {
+@TestMethodOrder(MethodName.class)
+final class CascadingWithGenericsTest {
 
     /**
      * The Class Foo.
@@ -178,7 +178,7 @@ public final class CascadingWithGenericsTest {
      *            the foo
      */
     @Test
-    public void cascadeOneLevelDuringReplay(@Mocked Foo foo) {
+    void cascadeOneLevelDuringReplay(@Mocked Foo foo) {
         assertNotNull(foo.returnTypeWithWildcard());
         assertNotNull(foo.returnTypeWithBoundedTypeVariable());
 
@@ -195,7 +195,7 @@ public final class CascadingWithGenericsTest {
      *            the mock foo
      */
     @Test
-    public void cascadeOneLevelDuringRecord(@Mocked Callable<String> action, @Mocked Foo mockFoo) {
+    void cascadeOneLevelDuringRecord(@Mocked Callable<String> action, @Mocked Foo mockFoo) {
         Foo foo = new Foo();
         Callable<?> cascaded = foo.returnTypeWithWildcard();
 
@@ -209,7 +209,7 @@ public final class CascadingWithGenericsTest {
      *            the mock foo
      */
     @Test
-    public void cascadeTwoLevelsDuringRecord(@Mocked final Foo mockFoo) {
+    void cascadeTwoLevelsDuringRecord(@Mocked final Foo mockFoo) {
         final Date now = new Date();
 
         new Expectations() {
@@ -259,7 +259,7 @@ public final class CascadingWithGenericsTest {
      *            the foo
      */
     @Test
-    public void cascadeGenericMethods(@Mocked GenericFoo<Baz, SubBar> foo) {
+    void cascadeGenericMethods(@Mocked GenericFoo<Baz, SubBar> foo) {
         Baz t = foo.returnTypeWithUnboundedTypeVariable();
         assertNotNull(t);
 
@@ -305,7 +305,7 @@ public final class CascadingWithGenericsTest {
      *            the a
      */
     @Test
-    public void cascadeOnMethodReturningAParameterizedClassWithAGenericMethod(@Injectable final A a) {
+    void cascadeOnMethodReturningAParameterizedClassWithAGenericMethod(@Injectable final A a) {
         new Expectations() {
             {
                 a.getB().getValue();
@@ -350,7 +350,7 @@ public final class CascadingWithGenericsTest {
      *            the mock
      */
     @Test
-    public void cascadeFromGenericMethodUsingTypeParameterOfSameNameAsTypeParameterFromBaseClass(@Mocked D mock) {
+    void cascadeFromGenericMethodUsingTypeParameterOfSameNameAsTypeParameterFromBaseClass(@Mocked D mock) {
         Bar cascaded = mock.doSomething();
 
         assertNotNull(cascaded);
@@ -416,7 +416,7 @@ public final class CascadingWithGenericsTest {
      *            the mock
      */
     @Test
-    public void cascadeDuringStaticInitializationOfCascadedClass(@Mocked Factory mock) {
+    void cascadeDuringStaticInitializationOfCascadedClass(@Mocked Factory mock) {
         assertNotNull(mock.staticInit());
         assertNotNull(WithStaticInit.T);
         assertNotNull(WithStaticInit.S);
@@ -429,8 +429,7 @@ public final class CascadingWithGenericsTest {
      *            the foo
      */
     @Test
-    public void cascadeFromGenericMethodWhereConcreteReturnTypeIsGivenByClassParameterButIsNotMockable(
-            @Mocked Foo foo) {
+    void cascadeFromGenericMethodWhereConcreteReturnTypeIsGivenByClassParameterButIsNotMockable(@Mocked Foo foo) {
         Integer n = foo.genericMethodWithNonMockableBoundedTypeVariableAndClassParameter(Integer.class);
 
         assertNotNull(n);
@@ -443,7 +442,7 @@ public final class CascadingWithGenericsTest {
      *            the foo
      */
     @Test
-    public void cascadeFromGenericMethodWhereConcreteReturnTypeIsGivenByClassParameter(@Mocked Foo foo) {
+    void cascadeFromGenericMethodWhereConcreteReturnTypeIsGivenByClassParameter(@Mocked Foo foo) {
         SubBar subBar = foo.genericMethodWithBoundedTypeVariableAndClassParameter(SubBar.class);
 
         assertNotNull(subBar);
@@ -461,7 +460,7 @@ public final class CascadingWithGenericsTest {
      *             the exception
      */
     @Test
-    public void cascadeFromGenericMethodWhoseReturnTypeComesFromParameterOnOwnerType(@Mocked Foo foo,
+    void cascadeFromGenericMethodWhoseReturnTypeComesFromParameterOnOwnerType(@Mocked Foo foo,
             @Mocked final Baz cascadedBaz) throws Exception {
         final Date date = new Date();
         new Expectations() {
@@ -511,7 +510,7 @@ public final class CascadingWithGenericsTest {
      *            the mock
      */
     @Test
-    public void cascadingFromGenericMethodWhoseTypeParameterExtendsAnother(@Mocked ConcreteInterface mock) {
+    void cascadingFromGenericMethodWhoseTypeParameterExtendsAnother(@Mocked ConcreteInterface mock) {
         Foo value = new Foo();
 
         Foo saved = mock.save(value);
@@ -547,7 +546,7 @@ public final class CascadingWithGenericsTest {
      *            the mock
      */
     @Test
-    public <T extends Serializable> void cascadeFromMethodReturningATypeVariable(
+    <T extends Serializable> void cascadeFromMethodReturningATypeVariable(
             @Mocked final GenericInterfaceWithBoundedTypeParameter<T> mock) {
         new Expectations() {
             {
@@ -587,7 +586,7 @@ public final class CascadingWithGenericsTest {
      *            the mock
      */
     @Test
-    public void cascadeFromMethodHavingUnusedTypeParameter(@Mocked TypeWithUnusedTypeParameterInGenericMethod mock) {
+    void cascadeFromMethodHavingUnusedTypeParameter(@Mocked TypeWithUnusedTypeParameterInGenericMethod mock) {
         Foo foo = mock.foo();
         Bar bar = foo.bar();
         assertNotNull(bar);
@@ -600,7 +599,7 @@ public final class CascadingWithGenericsTest {
      *            the mock
      */
     @Test
-    public void cascadeFromGenericMethodWhoseReturnTypeResolvesToAnotherGenericType(@Mocked B<C<?>> mock) {
+    void cascadeFromGenericMethodWhoseReturnTypeResolvesToAnotherGenericType(@Mocked B<C<?>> mock) {
         C<?> c = mock.getValue();
 
         assertNotNull(c);
@@ -643,7 +642,7 @@ public final class CascadingWithGenericsTest {
      *            the mock
      */
     @Test
-    public void cascadeFromGenericMethodDefinedTwoLevelsDeepInInheritanceHierarchy(@Mocked NonGenericInterface mock) {
+    void cascadeFromGenericMethodDefinedTwoLevelsDeepInInheritanceHierarchy(@Mocked NonGenericInterface mock) {
         Bar cascadedResult = mock.genericMethod();
 
         assertNotNull(cascadedResult);
@@ -671,7 +670,7 @@ public final class CascadingWithGenericsTest {
      *            the mock
      */
     @Test
-    public void cascadeFromGenericMethodOfNonPublicInterface(@Mocked NonPublicInterfaceWithGenericMethod mock) {
+    void cascadeFromGenericMethodOfNonPublicInterface(@Mocked NonPublicInterfaceWithGenericMethod mock) {
         Runnable result = mock.doSomething();
 
         assertNotNull(result);
@@ -701,7 +700,7 @@ public final class CascadingWithGenericsTest {
      *            the mock
      */
     @Test
-    public void cascadeFromGenericMethodWithClassParameterOfMockedInterface(@Mocked FactoryInterface mock) {
+    void cascadeFromGenericMethodWithClassParameterOfMockedInterface(@Mocked FactoryInterface mock) {
         Foo cascaded = mock.genericWithClass(Foo.class);
 
         assertNotNull(cascaded);
@@ -743,8 +742,8 @@ public final class CascadingWithGenericsTest {
      *            the mock
      */
     @Test
-    public void cascadeFromMethodReturningInnerInstanceOfGenericClass(@Mocked final Client mock) {
-        final Outer<?>.Inner innerInstance = new Outer<Object>().new Inner();
+    void cascadeFromMethodReturningInnerInstanceOfGenericClass(@Mocked final Client mock) {
+        final Outer<?>.Inner innerInstance = new Outer().new Inner();
 
         new Expectations() {
             {
@@ -786,7 +785,7 @@ public final class CascadingWithGenericsTest {
      *            the mock
      */
     @Test
-    public void cascadeFromMethodReturningInstanceOfGenericSubclassThenFromGenericMethodOfGenericBaseClass(
+    void cascadeFromMethodReturningInstanceOfGenericSubclassThenFromGenericMethodOfGenericBaseClass(
             @Mocked ClassWithMethodReturningGenericClassInstance mock) {
         SubB<C<?>> cascade1 = mock.doSomething();
         C<?> cascade2 = cascade1.getValue();
@@ -837,7 +836,7 @@ public final class CascadingWithGenericsTest {
      *            the mock
      */
     @Test
-    public void cascadeFromGenericInterfaceMethodImplementedInBaseClassOfMockedSubClass(@Mocked SubClass mock) {
+    void cascadeFromGenericInterfaceMethodImplementedInBaseClassOfMockedSubClass(@Mocked SubClass mock) {
         Bar cascaded = mock.genericMethod();
         assertNotNull(cascaded);
     }

--- a/main/src/test/java/mockit/ClassLoadingAndJREMocksTest.java
+++ b/main/src/test/java/mockit/ClassLoadingAndJREMocksTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -16,12 +17,12 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The Class ClassLoadingAndJREMocksTest.
  */
-public final class ClassLoadingAndJREMocksTest {
+class ClassLoadingAndJREMocksTest {
 
     /**
      * The Class Foo.
@@ -33,7 +34,7 @@ public final class ClassLoadingAndJREMocksTest {
      * Fake file.
      */
     @Test
-    public void fakeFile() {
+    void fakeFile() {
         new MockUp<File>() {
             @Mock
             void $init(String name) {
@@ -53,7 +54,7 @@ public final class ClassLoadingAndJREMocksTest {
      * Fake file safely using reentrant fake method.
      */
     @Test
-    public void fakeFileSafelyUsingReentrantFakeMethod() {
+    void fakeFileSafelyUsingReentrantFakeMethod() {
         new MockUp<File>() {
             @Mock
             boolean exists(Invocation inv) {
@@ -79,7 +80,7 @@ public final class ClassLoadingAndJREMocksTest {
      * Fake file safely using proceed.
      */
     @Test
-    public void fakeFileSafelyUsingProceed() {
+    void fakeFileSafelyUsingProceed() {
         new MockUp<File>() {
             @Mock
             boolean exists(Invocation inv) {
@@ -98,7 +99,7 @@ public final class ClassLoadingAndJREMocksTest {
      *            the mock
      */
     @Test
-    public void attemptToMockNonMockableJREClass(@Mocked Integer mock) {
+    void attemptToMockNonMockableJREClass(@Mocked Integer mock) {
         assertNull(mock);
     }
 
@@ -114,7 +115,7 @@ public final class ClassLoadingAndJREMocksTest {
      *             the exception
      */
     @Test
-    public void mockURLAndURLConnection(@Mocked URL mockUrl, @Mocked URLConnection mockConnection) throws Exception {
+    void mockURLAndURLConnection(@Mocked URL mockUrl, @Mocked URLConnection mockConnection) throws Exception {
         URLConnection conn = mockUrl.openConnection();
 
         assertSame(mockConnection, conn);
@@ -132,8 +133,7 @@ public final class ClassLoadingAndJREMocksTest {
      *             the exception
      */
     @Test
-    public void mockURLAndHttpURLConnection(@Mocked URL mockUrl, @Mocked HttpURLConnection mockConnection)
-            throws Exception {
+    void mockURLAndHttpURLConnection(@Mocked URL mockUrl, @Mocked HttpURLConnection mockConnection) throws Exception {
         HttpURLConnection conn = (HttpURLConnection) mockUrl.openConnection();
         assertSame(mockConnection, conn);
     }
@@ -148,7 +148,7 @@ public final class ClassLoadingAndJREMocksTest {
      *             the exception
      */
     @Test
-    public void mockURLAndHttpURLConnectionWithDynamicMock(@Mocked final HttpURLConnection mockHttpConnection)
+    void mockURLAndHttpURLConnectionWithDynamicMock(@Mocked final HttpURLConnection mockHttpConnection)
             throws Exception {
         final URL url = new URL("http://nowhere");
 
@@ -207,7 +207,7 @@ public final class ClassLoadingAndJREMocksTest {
      *             the exception
      */
     @Test
-    public void cascadingMockedURLWithInjectableCascadedURLConnection(@Mocked URL anyUrl,
+    void cascadingMockedURLWithInjectableCascadedURLConnection(@Mocked URL anyUrl,
             @Injectable final URLConnection cascadedUrlConnection) throws Exception {
         String testContent = recordURLConnectionToReturnContent(cascadedUrlConnection);
 
@@ -248,7 +248,7 @@ public final class ClassLoadingAndJREMocksTest {
      *             the exception
      */
     @Test
-    public void fakeURLUsingInjectableURLConnection(@Injectable final URLConnection urlConnection) throws Exception {
+    void fakeURLUsingInjectableURLConnection(@Injectable final URLConnection urlConnection) throws Exception {
         final String testContent = recordURLConnectionToReturnContent(urlConnection);
         new MockUp<URL>() {
             @Mock
@@ -272,7 +272,9 @@ public final class ClassLoadingAndJREMocksTest {
      * @param mockClass
      *            the mock class
      */
-    @Test(expected = IllegalArgumentException.class)
+    @org.junit.Test(expected = IllegalArgumentException.class)
     public void attemptToMockJREClassThatIsNeverMockable(@Mocked Class<?> mockClass) {
+        fail("Should never get here");
     }
+
 }


### PR DESCRIPTION
…lmost entirely to junit 5 as it crashed after this change