### PR TITLE
[logging] Use slf4j now in jmockit

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -110,7 +110,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/main/src/main/java/mockit/coverage/AccretionFile.java
+++ b/main/src/main/java/mockit/coverage/AccretionFile.java
@@ -11,7 +11,14 @@ import java.io.IOException;
 
 import mockit.coverage.data.CoverageData;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 final class AccretionFile {
+
+    /** The logger. */
+    private static final Logger logger = LoggerFactory.getLogger(AccretionFile.class);
+
     @NonNull
     private final File outputFile;
     @NonNull
@@ -34,6 +41,6 @@ final class AccretionFile {
 
     void generate() throws IOException {
         newData.writeDataToFile(outputFile);
-        System.out.println("JMockit: Coverage data written to " + outputFile.getCanonicalPath());
+        logger.info("JMockit: Coverage data written to {}", outputFile.getCanonicalPath());
     }
 }

--- a/main/src/main/java/mockit/coverage/CoverageCheck.java
+++ b/main/src/main/java/mockit/coverage/CoverageCheck.java
@@ -16,8 +16,14 @@ import java.util.regex.Pattern;
 import mockit.coverage.data.CoverageData;
 
 import org.checkerframework.checker.index.qual.NonNegative;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class CoverageCheck {
+
+    /** The logger. */
+    private static final Logger logger = LoggerFactory.getLogger(CoverageCheck.class);
+
     private static final String configuration = Configuration.getProperty("check", "");
 
     @Nullable
@@ -82,8 +88,7 @@ final class CoverageCheck {
 
         private boolean verifyMinimum(@NonNegative int percentage) {
             if (percentage < minPercentage) {
-                System.out.println("JMockit: coverage too low" + scopeDescription + ": " + percentage + "% < "
-                        + minPercentage + '%');
+                logger.info("JMockit: coverage too low {}: {}% < {}%", scopeDescription, percentage, minPercentage);
                 return false;
             }
 

--- a/main/src/main/java/mockit/coverage/OutputFileGenerator.java
+++ b/main/src/main/java/mockit/coverage/OutputFileGenerator.java
@@ -13,8 +13,15 @@ import java.io.IOException;
 import mockit.coverage.data.CoverageData;
 import mockit.coverage.reporting.CoverageReport;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @SuppressWarnings("DynamicRegexReplaceableByCompiledPattern")
 final class OutputFileGenerator {
+
+    /** The logger. */
+    private static final Logger logger = LoggerFactory.getLogger(CoverageReport.class);
+
     private static final String[] ALL_SOURCE_DIRS = {};
 
     @NonNull
@@ -72,18 +79,19 @@ final class OutputFileGenerator {
         CoverageData coverageData = CoverageData.instance();
 
         if (coverageData.isEmpty()) {
-            System.out.print("JMockit: No classes were instrumented for coverage; please make sure that ");
+            logger.info("JMockit: No classes were instrumented for coverage; please make sure that ");
 
             String classesRegexp = Configuration.getProperty("classes");
 
             if (classesRegexp == null) {
-                System.out.print("classes exercised by tests are in a directory included in the runtime classpath");
+                logger.info("classes exercised by tests are in a directory included in the runtime classpath");
             } else {
-                System.out.print("classes selected for coverage through the regular expression \"" + classesRegexp
-                        + "\" are available from the runtime classpath");
+                logger.info(
+                        "classes selected for coverage through the regular expression '{}' are available from the runtime classpath",
+                        classesRegexp);
             }
 
-            System.out.println(", and that they have been compiled with debug information.");
+            logger.info(", and that they have been compiled with debug information.");
             return;
         }
 

--- a/main/src/main/java/mockit/coverage/XmlFile.java
+++ b/main/src/main/java/mockit/coverage/XmlFile.java
@@ -19,6 +19,8 @@ import mockit.coverage.lines.LineCoverageData;
 import mockit.coverage.lines.PerFileLineCoverage;
 
 import org.checkerframework.checker.index.qual.NonNegative;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Generates a XML file containing the coverage data gathered by the test run. The XML schema used is the one
@@ -34,6 +36,10 @@ import org.checkerframework.checker.index.qual.NonNegative;
  * }</pre>
  */
 final class XmlFile {
+
+    /** The logger. */
+    private static final Logger logger = LoggerFactory.getLogger(XmlFile.class);
+
     @NonNull
     private final String srcDir;
     @NonNull
@@ -69,7 +75,7 @@ final class XmlFile {
             out.write("</coverage>\n");
         }
 
-        System.out.println("JMockit: Coverage data written to " + outputFile.getCanonicalPath());
+        logger.info("JMockit: Coverage data written to {}", outputFile.getCanonicalPath());
     }
 
     private void writeOpeningXmlElementForSourceFile(@NonNull Writer out, @NonNull String sourceFileName)

--- a/main/src/main/java/mockit/coverage/reporting/CoverageReport.java
+++ b/main/src/main/java/mockit/coverage/reporting/CoverageReport.java
@@ -24,7 +24,14 @@ import mockit.coverage.reporting.packages.IndexPage;
 import mockit.coverage.reporting.sourceFiles.FileCoverageReport;
 import mockit.coverage.reporting.sourceFiles.InputFile;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public final class CoverageReport {
+
+    /** The logger. */
+    private static final Logger logger = LoggerFactory.getLogger(CoverageReport.class);
+
     @NonNull
     private final String outputDir;
     private boolean outputDirCreated;
@@ -61,7 +68,7 @@ public final class CoverageReport {
         boolean withSourceFilePages = sourceDirs != null;
 
         if (withSourceFilePages && sourceDirs.size() > 1) {
-            System.out.println("JMockit: Coverage source dirs: " + sourceDirs);
+            logger.info("JMockit: Coverage source dirs: {}", sourceDirs);
         }
 
         generateFileCoverageReportsWhileBuildingPackageLists();
@@ -69,7 +76,7 @@ public final class CoverageReport {
         new StaticFiles(outputDir).copyToOutputDir(withSourceFilePages);
         new IndexPage(outputFile, sourceDirs, sourceFilesNotFound, packageToFiles, fileToFileData).generate();
 
-        System.out.println("JMockit: Coverage report written to " + outputFile.getParentFile().getCanonicalPath());
+        logger.info("JMockit: Coverage report written to {}", outputFile.getParentFile().getCanonicalPath());
     }
 
     private void createReportOutputDirIfNotExists() {
@@ -84,8 +91,7 @@ public final class CoverageReport {
         File outputFile = new File(outputDir, "index.html");
 
         if (outputFile.exists() && !outputFile.canWrite()) {
-            System.out
-                    .println("JMockit: " + outputFile.getCanonicalPath() + " is read-only; report generation canceled");
+            logger.info("JMockit: {} is read-only; report generation canceled", outputFile.getCanonicalPath());
             return null;
         }
 

--- a/main/src/test/java/mockit/CapturingImplementationsTest.java
+++ b/main/src/test/java/mockit/CapturingImplementationsTest.java
@@ -26,11 +26,16 @@ import mockit.internal.ClassFile;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Class CapturingImplementationsTest.
  */
 final class CapturingImplementationsTest {
+
+    /** The logger. */
+    private static final Logger logger = LoggerFactory.getLogger(CapturingImplementationsTest.class);
 
     /**
      * The Interface ServiceToBeStubbedOut.
@@ -467,7 +472,7 @@ final class CapturingImplementationsTest {
          *            the t
          */
         void doSomething(T t) {
-            System.out.println("test");
+            logger.info("test");
         }
 
         /**

--- a/main/src/test/java/mockit/MockUpForSingleInterfaceInstanceTest.java
+++ b/main/src/test/java/mockit/MockUpForSingleInterfaceInstanceTest.java
@@ -12,8 +12,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class MockUpForSingleInterfaceInstanceTest {
+
+    /** The logger. */
+    private static final Logger logger = LoggerFactory.getLogger(MockUpForSingleInterfaceInstanceTest.class);
+
     public interface APublicInterface {
         int getNumericValue();
 
@@ -111,7 +117,7 @@ public final class MockUpForSingleInterfaceInstanceTest {
 
         for (int i = 0; i < n; i++) {
             if (Thread.interrupted()) {
-                System.out.println("a) Interrupted at i = " + i);
+                logger.info("a) Interrupted at i = {}", i);
                 return;
             }
 
@@ -129,7 +135,7 @@ public final class MockUpForSingleInterfaceInstanceTest {
 
         for (int i = 0; i < n; i++) {
             if (Thread.interrupted()) {
-                System.out.println("b) Interrupted at i = " + i);
+                logger.info("b) Interrupted at i = {}", i);
                 return;
             }
 

--- a/main/src/test/java/otherTests/JUnit4Test.java
+++ b/main/src/test/java/otherTests/JUnit4Test.java
@@ -19,11 +19,16 @@ import mockit.Mocked;
 import mockit.Verifications;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Class JUnit4Test.
  */
 public final class JUnit4Test {
+
+    /** The logger. */
+    private static final Logger logger = LoggerFactory.getLogger(JUnit4Test.class);
 
     /** The mock. */
     @Mocked
@@ -81,8 +86,8 @@ public final class JUnit4Test {
          *            the str
          */
         void doSomething(int i, long l, Short s, byte b, char c, double d, float f, String str) {
-            System.out.println(i + l + s + b + d + f);
-            System.out.println(c + str);
+            logger.info("{}", i + l + s + b + d + f);
+            logger.info("{}", c + str);
         }
 
         /**


### PR DESCRIPTION
for now users will need to supply an implementation during their tests as does most things using slf4j apis.