### PR TITLE
Preserve PermittedSubclasses attribute so sealed classes can be mocked

### DIFF
--- a/main/src/main/java/mockit/asm/classes/ClassInfo.java
+++ b/main/src/main/java/mockit/asm/classes/ClassInfo.java
@@ -52,4 +52,11 @@ public final class ClassInfo {
      */
     @Nullable
     String[] nestMembers;
+
+    /**
+     * The internal names of the permitted direct subclasses of this sealed class, if any (Java 17+ only). Carried
+     * verbatim so a redefined class keeps the same PermittedSubclasses attribute the JVM requires to stay unchanged.
+     */
+    @Nullable
+    String[] permittedSubclasses;
 }

--- a/main/src/main/java/mockit/asm/classes/ClassReader.java
+++ b/main/src/main/java/mockit/asm/classes/ClassReader.java
@@ -154,6 +154,11 @@ public final class ClassReader extends AnnotatedReader {
             return true;
         }
 
+        if ("PermittedSubclasses".equals(attributeName)) {
+            readPermittedSubclasses();
+            return true;
+        }
+
         if ("BootstrapMethods".equals(attributeName)) {
             readBootstrapMethods();
             return true;
@@ -176,6 +181,17 @@ public final class ClassReader extends AnnotatedReader {
         }
 
         classInfo.nestMembers = nestMembers;
+    }
+
+    private void readPermittedSubclasses() {
+        int numberOfClasses = readUnsignedShort();
+        String[] permittedSubclasses = new String[numberOfClasses];
+
+        for (int i = 0; i < numberOfClasses; i++) {
+            permittedSubclasses[i] = readNonnullClass();
+        }
+
+        classInfo.permittedSubclasses = permittedSubclasses;
     }
 
     private void readBootstrapMethods() {

--- a/main/src/main/java/mockit/asm/classes/ClassWriter.java
+++ b/main/src/main/java/mockit/asm/classes/ClassWriter.java
@@ -137,6 +137,7 @@ public final class ClassWriter extends ClassVisitor {
         createSignatureWriterIfApplicable(additionalInfo.signature);
         createSourceFileWriterIfApplicable(additionalInfo.sourceFileName);
         createNestWritersIfApplicable(additionalInfo.hostClassName, additionalInfo.nestMembers);
+        createPermittedSubclassesWriterIfApplicable(additionalInfo.permittedSubclasses);
 
         if (superName != null) {
             ClassLoad.addSuperClass(name, superName);
@@ -166,6 +167,12 @@ public final class ClassWriter extends ClassVisitor {
             attributeWriters.add(new NestHostWriter(cp, hostClassName));
         } else if (memberClassNames != null) {
             attributeWriters.add(new NestMembersWriter(cp, memberClassNames));
+        }
+    }
+
+    private void createPermittedSubclassesWriterIfApplicable(@Nullable String[] permittedSubclasses) {
+        if (permittedSubclasses != null) {
+            attributeWriters.add(new PermittedSubclassesWriter(cp, permittedSubclasses));
         }
     }
 

--- a/main/src/main/java/mockit/asm/classes/PermittedSubclassesWriter.java
+++ b/main/src/main/java/mockit/asm/classes/PermittedSubclassesWriter.java
@@ -1,0 +1,51 @@
+/*
+ * MIT License
+ * Copyright (c) 2006-2025 JMockit developers
+ * See LICENSE file for full license text.
+ */
+package mockit.asm.classes;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import mockit.asm.constantPool.AttributeWriter;
+import mockit.asm.constantPool.ConstantPoolGeneration;
+import mockit.asm.util.ByteVector;
+
+import org.checkerframework.checker.index.qual.NonNegative;
+
+/**
+ * Generates the "PermittedSubclasses" attribute of a sealed class (Java 17+). The attribute is a u2 count followed by
+ * that many u2 CONSTANT_Class indices, structurally identical to "NestMembers". Preserving it verbatim lets a redefined
+ * sealed class keep the attribute the JVM requires to stay unchanged across redefinition.
+ */
+final class PermittedSubclassesWriter extends AttributeWriter {
+    @NonNegative
+    private final int[] permittedSubclassIndices;
+
+    PermittedSubclassesWriter(@NonNull ConstantPoolGeneration cp, @NonNull String[] permittedSubclassNames) {
+        super(cp, "PermittedSubclasses");
+
+        permittedSubclassIndices = new int[permittedSubclassNames.length];
+
+        for (int i = 0; i < permittedSubclassNames.length; i++) {
+            permittedSubclassIndices[i] = cp.newClass(permittedSubclassNames[i]);
+        }
+    }
+
+    @NonNegative
+    @Override
+    public int getSize() {
+        return 8 + 2 * permittedSubclassIndices.length;
+    }
+
+    @Override
+    public void put(@NonNull ByteVector out) {
+        int numberOfSubclasses = permittedSubclassIndices.length;
+        put(out, 2 + 2 * numberOfSubclasses);
+        out.putShort(numberOfSubclasses);
+
+        for (int permittedSubclassIndex : permittedSubclassIndices) {
+            out.putShort(permittedSubclassIndex);
+        }
+    }
+}

--- a/main/src/test/java/mockit/CascadingParametersTest.java
+++ b/main/src/test/java/mockit/CascadingParametersTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.Future;
 import mockit.integration.junit5.JMockitExtension;
 import mockit.internal.expectations.invocation.MissingInvocation;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -613,10 +612,6 @@ class CascadingParametersTest {
      * @throws Exception
      *             the exception
      */
-    // TODO JWL 2/18/2024 Mocking Socket/InetAddress is not allowed on JDK9+ because java.net classes reside in a
-    // restricted JDK module that the JVM does not allow to be modified. To test code that depends on these classes,
-    // consider wrapping network operations behind a testable interface or abstraction that can be mocked instead.
-    @Disabled
     @Test
     void recordAndVerifyExpectationsOnCascadedMocks(@Mocked Socket anySocket,
             @Mocked final SocketChannel cascadedChannel, @Mocked InetSocketAddress inetAddr) throws Exception {

--- a/main/src/test/java/mockit/ClassLoadingAndJREMocksTest.java
+++ b/main/src/test/java/mockit/ClassLoadingAndJREMocksTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -18,9 +19,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.net.UnknownHostException;
 import java.nio.file.Path;
 
 import mockit.integration.junit5.ExpectedException;
@@ -289,4 +292,103 @@ class ClassLoadingAndJREMocksTest {
         fail("Should never get here");
     }
 
+    // The following tests exercise mocking of java.net.InetAddress, which is a sealed class as of JDK 17
+    // (it permits Inet4Address and Inet6Address). Mocking a sealed class requires JMockit to redefine it
+    // while preserving its PermittedSubclasses attribute; dropping that attribute makes the JVM reject the
+    // redefinition ("attempted to change the class ... PermittedSubclasses attribute"). These end-to-end
+    // tests confirm that a sealed JRE class is fully mockable: instance-method stubbing, static-method
+    // stubbing, and recorded exceptions all behave as they did before sealed classes existed.
+
+    /**
+     * Mocks an instance method of the sealed {@link InetAddress} class.
+     *
+     * @param mockAddress
+     *            the mock address
+     */
+    @Test
+    void mockInstanceMethodOfSealedInetAddress(@Mocked InetAddress mockAddress) {
+        new Expectations() {
+            {
+                mockAddress.getHostName();
+                result = "mocked-host";
+                mockAddress.getHostAddress();
+                result = "10.0.0.5";
+            }
+        };
+
+        assertEquals("mocked-host", mockAddress.getHostName());
+        assertEquals("10.0.0.5", mockAddress.getHostAddress());
+    }
+
+    /**
+     * Mocks the static {@link InetAddress#getByName(String)} factory and stubs the resulting instance.
+     *
+     * @param anyAddress
+     *            any mocked address instance
+     *
+     * @throws Exception
+     *             the exception
+     */
+    @Test
+    void mockStaticFactoryOfSealedInetAddress(@Mocked InetAddress anyAddress) throws Exception {
+        new Expectations() {
+            {
+                InetAddress.getByName("db.example.com");
+                result = anyAddress;
+                anyAddress.getHostAddress();
+                result = "192.0.2.7";
+            }
+        };
+
+        InetAddress resolved = InetAddress.getByName("db.example.com");
+        assertSame(anyAddress, resolved);
+        assertEquals("192.0.2.7", resolved.getHostAddress());
+    }
+
+    /**
+     * Mocks the static {@link InetAddress#getLocalHost()} factory, a common seam for tests that must not depend on the
+     * host's real name resolution.
+     *
+     * @param anyAddress
+     *            any mocked address instance
+     *
+     * @throws Exception
+     *             the exception
+     */
+    @Test
+    void mockLocalHostOfSealedInetAddress(@Mocked InetAddress anyAddress) throws Exception {
+        new Expectations() {
+            {
+                InetAddress.getLocalHost();
+                result = anyAddress;
+                anyAddress.getHostName();
+                result = "myhost.local";
+            }
+        };
+
+        assertEquals("myhost.local", InetAddress.getLocalHost().getHostName());
+    }
+
+    /**
+     * Records a checked {@link UnknownHostException} from the mocked static factory, confirming exception recording
+     * works for a sealed class.
+     *
+     * @param anyAddress
+     *            any mocked address instance
+     */
+    @Test
+    void recordCheckedExceptionFromSealedInetAddress(@Mocked InetAddress anyAddress) {
+        new Expectations() {
+            {
+                try {
+                    InetAddress.getByName(anyString);
+                    result = new UnknownHostException("unresolved");
+                } catch (UnknownHostException ignore) {
+                    // The recorded call declares a checked exception; recording it cannot actually throw.
+                }
+            }
+        };
+
+        assertThrows(UnknownHostException.class, () -> InetAddress.getByName("no.such.host"));
+    }
 }

--- a/main/src/test/java/mockit/asm/classes/ClassReaderTest.java
+++ b/main/src/test/java/mockit/asm/classes/ClassReaderTest.java
@@ -179,4 +179,123 @@ final class ClassReaderTest {
         assertNotNull(result);
         assertTrue(result.length > 0);
     }
+
+    /**
+     * java.net.InetAddress is sealed (JDK 17+), so its classfile carries a PermittedSubclasses attribute.
+     * Round-tripping it through ClassReader -> ClassWriter must preserve that attribute; otherwise the JVM rejects a
+     * redefinition of the class with "attempted to change the class ... PermittedSubclasses attribute". This asserts
+     * the attribute survives in the emitted class-level attribute table, not merely that some bytes came out. (Checking
+     * the constant pool would be meaningless: the pool is copied wholesale, so the "PermittedSubclasses" UTF8 entry
+     * survives regardless of whether the attribute itself is written.)
+     */
+    @Test
+    void preservesPermittedSubclassesAttributeOnSealedClass() {
+        byte[] code = ClassFile.readBytesFromClassFile(java.net.InetAddress.class);
+        assertTrue(hasClassAttribute(code, "PermittedSubclasses"),
+                "test premise: InetAddress should be sealed (carry PermittedSubclasses) on this JDK");
+
+        ClassReader reader = new ClassReader(code);
+        ClassWriter writer = new ClassWriter(reader);
+        reader.accept(writer);
+        byte[] result = writer.toByteArray();
+
+        assertNotNull(result);
+        assertTrue(hasClassAttribute(result, "PermittedSubclasses"),
+                "PermittedSubclasses attribute must be preserved in the rewritten sealed class");
+    }
+
+    /**
+     * Structurally parses a class file down to its class-level attribute table and reports whether an attribute with
+     * the given name is present there. Unlike a constant-pool scan, this reflects what the writer actually emitted, so
+     * it distinguishes a preserved attribute from a merely-copied name entry.
+     */
+    private static boolean hasClassAttribute(byte[] cf, String attributeName) {
+        String[] utf8 = new String[readUnsignedShort(cf, 8)];
+        int index = 10;
+
+        // Constant pool: record UTF8 values (to resolve attribute name indices) and skip everything by tag size.
+        for (int i = 1; i < utf8.length; i++) {
+            int tag = cf[index] & 0xFF;
+            index++;
+
+            switch (tag) {
+                case 1: // Utf8
+                    int length = readUnsignedShort(cf, index);
+                    utf8[i] = new String(cf, index + 2, length, java.nio.charset.StandardCharsets.UTF_8);
+                    index += 2 + length;
+                    break;
+                case 5: // Long
+                case 6: // Double
+                    index += 8;
+                    i++; // occupies two pool slots
+                    break;
+                case 7: // Class
+                case 8: // String
+                case 16: // MethodType
+                case 19: // Module
+                case 20: // Package
+                    index += 2;
+                    break;
+                case 15: // MethodHandle
+                    index += 3;
+                    break;
+                default: // Integer/Float/Fieldref/Methodref/InterfaceMethodref/NameAndType/Dynamic/InvokeDynamic
+                    index += 4;
+                    break;
+            }
+        }
+
+        index += 6; // access_flags, this_class, super_class
+        index += 2 + 2 * readUnsignedShort(cf, index); // interfaces_count + interfaces[]
+        index = skipMembers(cf, index); // fields[]
+        index = skipMembers(cf, index); // methods[]
+
+        // Class-level attributes table: attributes_count (u2) then attribute_info[].
+        int attrCount = readUnsignedShort(cf, index);
+        index += 2;
+
+        for (int a = 0; a < attrCount; a++) {
+            int nameIndex = readUnsignedShort(cf, index);
+            int attrLength = readInt(cf, index + 2);
+            index += 6;
+
+            if (attributeName.equals(utf8[nameIndex])) {
+                return true;
+            }
+
+            index += attrLength;
+        }
+
+        return false;
+    }
+
+    /**
+     * Skips a fields[] or methods[] table (both have identical member_info layout), returning the offset just past it.
+     */
+    private static int skipMembers(byte[] cf, int index) {
+        int count = readUnsignedShort(cf, index);
+        index += 2;
+
+        for (int m = 0; m < count; m++) {
+            index += 6; // access_flags, name_index, descriptor_index
+
+            int attrCount = readUnsignedShort(cf, index);
+            index += 2;
+
+            for (int a = 0; a < attrCount; a++) {
+                int attrLength = readInt(cf, index + 2); // skip name_index (u2), read length (u4)
+                index += 6 + attrLength;
+            }
+        }
+
+        return index;
+    }
+
+    private static int readUnsignedShort(byte[] b, int i) {
+        return (b[i] & 0xFF) << 8 | b[i + 1] & 0xFF;
+    }
+
+    private static int readInt(byte[] b, int i) {
+        return (b[i] & 0xFF) << 24 | (b[i + 1] & 0xFF) << 16 | (b[i + 2] & 0xFF) << 8 | b[i + 3] & 0xFF;
+    }
 }


### PR DESCRIPTION
## Problem

The bundled ASM (`mockit.asm`) reads and rewrites every class attribute it recognizes, but has no handling for the `PermittedSubclasses` attribute that sealed classes carry since Java 17. When JMockit redefines a sealed class (for example `java.net.InetAddress`, which permits `Inet4Address` and `Inet6Address`), that attribute is silently dropped on the read → write round-trip.

This did not matter on JDK 17, where such a redefinition still succeeded. On JDK 21 the JVM's class-redefinition verification rejects a redefinition that changes the `PermittedSubclasses` attribute:

  `java.lang.UnsupportedOperationException: class redefinition failed: attempted to change the class NestHost, NestMembers, Record, or PermittedSubclasses attribute`

So `@Mocked` / `@Injectable` of a sealed type stopped working after upgrading from JDK 17 to JDK 21.

**Verified directly:** the same unpatched jmockit jar mocks a sealed `java.net.InetAddress` successfully on JDK 17.0.x but fails with the above error on JDK 21.0.x. The attribute was always dropped; what changed is the JVM's redefinition verification between those releases.

## Fix

Carry the attribute through verbatim, mirroring the existing `NestMembers` handling:

  - **`ClassInfo`** — add a `permittedSubclasses` field to hold the parsed names.
  - **`ClassReader`** — recognize the `"PermittedSubclasses"` attribute and read its `u2` count + `u2[]` `CONSTANT_Class` indices into `ClassInfo`.
  - **`PermittedSubclassesWriter`** (new) — an `AttributeWriter` that re-emits the attribute; structurally identical to `NestMembersWriter`.
  - **`ClassWriter`** — emit the writer when `permittedSubclasses` is present.

## Tests

  - **`ClassReaderTest`** — assert the `PermittedSubclasses` attribute survives a `ClassReader → ClassWriter` round-trip of the sealed
  `java.net.InetAddress` (inspects the emitted class-attribute table, not just the constant pool, since the pool is copied wholesale regardless).
  - **`ClassLoadingAndJREMocksTest`** — end-to-end mocking of the sealed `InetAddress`: instance-method stubbing, the static `getByName` / `getLocalHost` factories, and a recorded `UnknownHostException`.
  - **`CascadingParametersTest`** — re-enable `recordAndVerifyExpectationsOnCascadedMocks` (mocks `Socket` / `SocketChannel` / `InetSocketAddress`), previously `@Disabled` because these `java.net` types could not be redefined.
